### PR TITLE
feat(encoders/decoders): add encoder/decoder support, closes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Also, `Promise`s.
 There are two (2) main issues which users of MQTT.js will quickly encounter:
 
 1.  You can't just set a listener function for a subscribed topic; you have to stuff logic into a listener on the `message` event, and figure out what to do with the topic.
-2.  Received messages are all `Buffer`s, and when publishing, your message must be a `string`, `Buffer`.
+2.  Received messages are all `Buffer` objects, and you can only publish a `Buffer` or `string`.
 3. (BONUS ISSUE) It doesn't use `Promise`s, which some people prefer over callbacks.
 
-`mqttletoad` solves the *first* problem and the *third* problem.
+`mqttletoad` solves the above problems.  These are problems I have, and likely many others have as well.
 
 ### Listeners for Specific Topics
 
@@ -57,41 +57,95 @@ We need something like a *router* (think [express](https://www.npmjs.com/package
 
 What's better is that `EventEmitter`s are standardized.  They are easy to consume.  Think [RxJs](https://npm.im/rxjs)'s `Observable.fromEvent()`.  This should help those using a "reactive" programming model.
 
+### Encoding and Decoding
+
+MQTT makes no prescriptions about what a message looks like.  It's just a [blob](https://en.wikipedia.org/wiki/Binary_large_object).
+
+But as a developer, you know your data.  Maybe that message is JSON, maybe it's base64-encoded, or maybe it's just a string.  You are unlikely to be surprised about what you get. 
+
+Out-of-the-box, `mqttletoad` provides several common *decoders* for received messages, and *encoders* for publishing messages.
+
+These are:
+
+- `json` - Convert to/from a JSON representation of an object
+- `text` - Convert to/from a UTF-8 encoded string
+- `binary` - Convert to a `Buffer` (all received messages are `Buffer`s, so no decoding necessary)
+- `base64` - Convert to/from a base64 (string) representation of just about anything
+
+To use these, you can specify a *default* encoder and/or decoder when connecting:
+
+```js
+const toad = require('mqttletoad');
+
+(async function () {
+  const client = await toad.connect('wss://test.mosquitto.org', {
+    encoder: 'json',
+    decoder: 'json'
+  });
+  
+  await client.subscribe('foo/bar', message => {
+    console.log(message.baz); // quux
+  });
+  
+  // see listener above
+  await client.publish('foo/bar', {baz: 'quux'});  
+}());
+```
+
+Or you can do this on a per-subscription/publish basis:
+
+```js
+const toad = require('mqttletoad');
+
+(async function () {
+  // "text" is the default encoder/decoder
+  const client = await toad.connect('wss://test.mosquitto.org', {
+    encoder: 'text',
+    decoder: 'text'
+  });
+  
+  await client.subscribe('foo/bar', message => {
+    console.log(message.baz); // quux
+  }, {decoder: 'json'});
+  
+  // see listener above
+  await client.publish('foo/bar', {baz: 'quux'}, {encoder: 'json'});   
+}());
+```
+
+You can also provide your own either way:
+
+```js
+const toad = require('mqttletoad');
+
+(async function() {
+  const client = await toad.connect('wss://test.mosquitto.org', {
+    decoder: parseFloat 
+  });
+  
+  await client.subscribe('foo/bar', message => {
+    console.log(message); // 123.4
+  });
+  
+  await client.subscribe('foo/bar', message => {
+    console.log(message); // '123.4'
+  }, {decoder: 'text'});
+  
+  // see listeners above
+  await client.publish('foo/bar', 123.4); // default encoder is "text"  
+}());
+```
+
 ### Promise Support
 
 [async-mqtt](https://npm.im/async-mqtt) does the same thing here--more or less.
 
-### WONTFIX: Message Formats
+The following functions are promisified:
 
-MQTT makes no prescriptions about what your message looks like.  It's just a [blob](https://en.wikipedia.org/wiki/Binary_large_object).  A JavaScript object is neither of these!  If you need to publish an object, call `JSON.stringify` on it first:
-
-```js
-const obj = {goin: 'on'};
-client.emit('fever/flavor', JSON.stringify(obj));
-```
-
-When subscribing, you will *always* receive a `Buffer`.  You'll need to unwrap it yourself:
-
-```js
-client.on('a/licky/boom/boom/down', buf => {
-  const obj = JSON.stringify(String(buf));
-});
-``` 
-
-A better idea may be to put some metadata in your topic about the message format, but again, this is up to you:
-
-```js
-const formatters = {
-  json: val => String(JSON.stringify),
-  text: String,
-  yaml: parseYaml
-};
-
-client.on('radscript/4ever/format/+', (buf, {topic})=> {
-  const format = topic.split('/').pop();
-  const result = formatters[format](buf);
-});
-```
+- `MqttClient#publish`
+- `MqttClient#subscribe`
+- `MqttClient#unsubscribe`
+- `MqttClient#end`
 
 ## Install
 
@@ -102,6 +156,8 @@ $ npm install mqttletoad
 ```
 
 ## Usage
+
+This is a fancypants wrapper around [MQTT.js](https://npm.im/mqtt), so most everything there applies here, except the differences noted above. 
 
 ```js
 const toad = require('mqttletoad');
@@ -116,28 +172,48 @@ const myfunc = async () => {
     console.warn('client offline; reconnecting...');
   });
   
-  // yes, `buf` is still a Buffer.
-  const suback = await client.subscribe('winken/+/nod', (buf, packet) => {
-    console.log(`topic: "${packet.topic}", message: "${String(buf)}"`);
+  // uses default "text" decoder
+  const suback = await client.subscribe('winken/+/nod', (str, packet) => {
+    console.log(`topic: "${packet.topic}", message: "${str}"`);
   }, {qos: 1});
   
   console.log(`subscribed to ${suback.topic} w/ QoS ${suback.qos}`);
   
+  // uses default "text" encoder
   await client.publish('winken/blinken/nod', 'foo');
+  
+  const someOtherListener = (message, packet) => {
+    // does stuff with MESSAGE
+  };
+  
+  // a custom decoder
+  await client.subscribe('winken/+/nod', someOtherListener, {
+    decoder: value => String(value).toUpperCase()
+  });
+  
+  // remove only this particular listener for this topic;
+  // no actual unsubscription occurs because this isn't the only listener
+  // on the topic.
+  await client.unsubscribe('winken/+/nod', someOtherListener);
+  
+  // remove ALL listeners from this topic and unsubscribe
+  await client.unsubscribe('winken/+/nod');
+  
+  // disconnect
+  await client.end();
 }
 ```
 
-## API
-
-Basically it's [async-mqtt](https://npm.im/async-mqtt) (which is [mqtt](https://npm.im/mqtt)) except:
-
 - Use `client.subscribe(topic, [opts], listener)` to *register a listener* for the topic. 
-  - `opts` are the standard options `mqtt.Client#subscribe()` supports
-  - While `mqtt.Client#subscribe()` supports an `Array` of topics, our `topic` is singular, and must be a string.
+  - `opts` are the standard options `MqttClient#subscribe()` supports, including `decoder`
+  - While `MqttClient#subscribe()` supports an `Array` of topics, our `topic` is singular, and *must* be a string.
   - Standard MQTT topic wildcards are supported, and listeners are executed first in order of specificity; i.e. `foo/bar` will take precedence over `foo/+` and `foo/+` will take precedence over `foo/#`.
 - Use `client.unsubscribe(topic, listener)` to remove the listener for the topic.
   - This will not necessarily *unsubscribe* from the topic (at the broker level), because there may be other listeners, but it *will* remove the listener.
-- `client.end()` won't throw a fit if already disconnected
+  - If `listener` is omitted, all listeners are removed, which forces unsubscription.
+- Use `client.end(force=false)` to disconnect 
+- Use `client.publish(topic, message, [opts])` with standard `MqttClient#publish()` options, including `encoder`
+- Use `connect(url, [opts])` to connect; `url` is a `string`, or you could just pass an `opts` object.  Includes `encoder` and `decoder` options, which set the default encoder and decoder, respectively.  The default is `text` in both cases.
 
 ## Roadmap
 

--- a/lib/decoders.js
+++ b/lib/decoders.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const atob = require('atob');
+
+/**
+ * JSON decoder
+ * @param {Buffer} value - Value to decode
+ * @returns {*} JSON representation of value
+ */
+const json = value => JSON.parse(value.toString('utf-8'));
+
+/**
+ * Base64 decoder
+ * @param {Buffer} value - Value to decode
+ * @returns {string} base64-encoded string
+ */
+const base64 = value => atob(value.toString('utf-8'));
+
+/**
+ * Text decoder
+ * @param {Buffer} value - Value to decode
+ * @returns {string} utf-8 encoded string
+ */
+const text = value => value.toString('utf-8');
+
+/**
+ * Binary decoder (does nothing)
+ * @param {Buffer} value - Value to decode
+ * @returns {Buffer} Unmolested `value`
+ */
+const binary = value => value;
+
+exports.json = json;
+exports.base64 = base64;
+exports.text = text;
+exports.binary = binary;

--- a/lib/encoders.js
+++ b/lib/encoders.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const btoa = require('btoa');
+
+/**
+ * JSON encoder
+ * @param {*} value - Value to encode
+ * @returns {string} JSON representation of value
+ */
+const json = JSON.stringify;
+
+/**
+ * Base64 encoder
+ * @param {*} value - Value to encode
+ * @returns {string} base64-encoded string
+ */
+const base64 = btoa;
+
+/**
+ * Text encoder
+ * @param {*} value - Value to encode
+ * @returns {string} text representation of string
+ */
+const text = String;
+
+/**
+ * Binary encoder
+ * @param {*} value - Value to encode
+ * @returns {Buffer} A Buffer representing the value
+ */
+const binary = value => Buffer.from(value);
+
+exports.json = json;
+exports.base64 = base64;
+exports.text = text;
+exports.binary = binary;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,10 @@
 const MQTT = require('mqtt');
 const pify = require('pify');
 const {EventEmitter2} = require('eventemitter2');
+const decoders = require('./decoders');
+const encoders = require('./encoders');
+
+const DEFAULT_OPTS = {decoder: decoders.text, encoder: encoders.text};
 
 const eventify = topic => topic.replace(/#/g, '**').replace(/\+/g, '*');
 
@@ -12,10 +16,14 @@ const asyncMethodNames = ['publish', 'subscribe', 'unsubscribe', 'end'];
  * Monkeypatches a `MqttClient` instance.
  * Promisifies `end`, `subscribe`, `publish`, and `unsubscribe`.
  * Adds special behavior around `on`, `once`, `removeListener`, `emit`, etc.
- * @param {MqttClient} client - MqttClient (does not mutate)
+ * @param {MqttClient} client - MqttClient (mutated)
+ * @param {Object} [baseOpts] - MqttClient options
+ * @param {string|Function} [baseOpts.decoder='text'] - Default decoder to use
+ *   on received messages (one of `json`, `text`, or `base64`) or a custom
+ *   decoder
  * @returns {MqttClient} Patched client
  */
-const toadpatch = client => {
+const toadpatch = (client, baseOpts = {}) => {
   const asyncMethods = asyncMethodNames.reduce(
     (acc, name) => Object.assign(acc, {[name]: pify(client[name])}),
     {}
@@ -34,12 +42,14 @@ const toadpatch = client => {
   /**
    * Subscribe to a topic with a specific listener.
    * @public
-   * @function
    * @param {string} topic - MQTT topic
    * @param {Function} listener - Listener function; called with  `message` and
    *   raw `packet`
    * @param {Object} [opts] - Any options for MQTT subscription
    * @param {number} [opts.qos=0] - QoS
+   * @param {string|Function} [opts.decoder] - Decoder to use; will default to
+   *   built-in or custom decoder supplied during `connect()`; if none
+   *   supplied, the default is the `text` decoder
    * @returns Promise<{{topic, qos}}> Object w/ topic subscribed to and QoS
    *   granted by broker
    */
@@ -48,9 +58,14 @@ const toadpatch = client => {
       throw new TypeError('Invalid parameters');
     }
 
+    opts = normalizeOptions(opts, baseOpts);
     const {toad} = this;
+    const {decoder} = opts;
     const event = eventify(topic);
-    toad.on(event, listener);
+
+    toad.on(event, (message, packet) => {
+      listener(decoder(message), packet);
+    });
 
     // TODO: find a way to not subscribe to already-subscribed topics
     // TODO: note that a different QoS requires a new subscription
@@ -69,18 +84,23 @@ const toadpatch = client => {
    * Only unsubscribes at broker level if no more listeners are registered for
    * the topic.
    * @public
-   * @function
    * @param {string} topic - MQTT topic
-   * @param {Function} listener - Listener function to remove
-   * @returns {Promise<void>}
+   * @param {Function} [listener] - Listener function to remove; if omitted, *all* listeners are removed, and the topic is unsubscribed.
+   * @returns {Promise<boolean>} `true` if unsubscribed, `false` if not
    */
   client.unsubscribe = async function toadUnsubscribe(topic, listener) {
     const {toad} = this;
     const event = eventify(topic);
-    toad.removeListener(event, listener);
-    if (!toad.listenerCount(event)) {
-      return asyncMethods.unsubscribe.call(this, topic);
+    if (!listener) {
+      toad.removeAllListeners(event);
+    } else {
+      toad.removeListener(event, listener);
     }
+    if (!toad.listenerCount(event)) {
+      await asyncMethods.unsubscribe.call(this, topic);
+      return true;
+    }
+    return false;
   };
 
   /**
@@ -98,11 +118,20 @@ const toadpatch = client => {
 
   /**
    * Publishes a message to a topic
-   * @function
    * @public
+   * @param topic
+   * @param message
+   * @param {Object} [opts] - `MqttClient#publish()` options
+   * @param {string|Function} [opts.encoder] - Encoder to use; will default to
+   *   built-in or custom decoder supplied during `connect()`; if none
+   *   supplied, the default is the `text` encoder
    * @returns {Promise<void>}
    */
-  client.publish = asyncMethods.publish;
+  client.publish = async function(topic, message, opts = {}) {
+    opts = normalizeOptions(opts, baseOpts);
+    const {encoder} = opts;
+    return asyncMethods.publish.call(this, topic, encoder(message), opts);
+  };
 
   /**
    * On any received message, delegate to the internal EE2 instance
@@ -115,6 +144,23 @@ const toadpatch = client => {
   return client;
 };
 
+const normalizeOptions = (opts = {}, defaults = DEFAULT_OPTS) => {
+  [['decoder', decoders], ['encoder', encoders]].forEach(([prop, builtins]) => {
+    if (opts.hasOwnProperty(prop)) {
+      if (typeof opts[prop] === 'string') {
+        const value = builtins[opts[prop]];
+        if (!value) {
+          throw new ReferenceError(`unknown ${prop} "${opts[prop]}"`);
+        }
+        opts[prop] = value;
+      } else if (typeof opts[prop] !== 'function') {
+        throw new TypeError(`${prop} must be string or function`);
+      }
+    }
+  });
+  return Object.assign(opts, defaults, opts);
+};
+
 /**
  * Accepts same parameters as `mqtt.connect`, except returns a `Promise`
  * which is fulfilled when the connection is made.
@@ -122,7 +168,18 @@ const toadpatch = client => {
  * @see https://www.npmjs.com/package/mqtt#connect
  * @returns {Promise<MqttClient>} Patched `MqttClient` instance
  */
-exports.connect = (...args) => {
+exports.connect = async (url, opts = {}) => {
+  if (typeof url === 'undefined') {
+    throw new Error('Invalid arguments');
+  }
+  let args;
+  if (typeof url === 'string') {
+    opts = normalizeOptions(opts);
+    args = [url, opts];
+  } else {
+    url = normalizeOptions(url);
+    args = [url];
+  }
   return new Promise((resolve, reject) => {
     MQTT.connect(...args)
       .on('connect', function(connack) {
@@ -135,7 +192,7 @@ exports.connect = (...args) => {
       })
       .once('error', reject)
       .once('connect', function() {
-        resolve(toadpatch(this));
+        resolve(toadpatch(this, opts));
       });
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,6 +349,11 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "atob": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -458,6 +463,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
+    },
+    "btoa": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.2.tgz",
+      "integrity": "sha1-PkC4FmP4HS3WWWpMtxSo3BbPq+A="
     },
     "builtin-modules": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   "author": "Christopher Hiller <boneskull@boneskull.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "atob": "^2.0.3",
+    "btoa": "^1.1.2",
     "eventemitter2": "^4.1.2",
-    "pify": "^3.0.0",
-    "mqtt": "^2.0.0"
+    "mqtt": "^2.0.0",
+    "pify": "^3.0.0"
   },
   "files": [
     "lib"

--- a/test/decoders.spec.js
+++ b/test/decoders.spec.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+'use strict';
+
+const expect = require('unexpected');
+const decoders = require('../lib/decoders');
+
+describe('decoders', function() {
+  describe('json', function() {
+    it('should convert a JSON string to its value', function() {
+      const value = Buffer.from(JSON.stringify({foo: 'bar'}));
+      expect(decoders.json(value), 'to equal', {foo: 'bar'});
+    });
+  });
+
+  describe('base64', function() {
+    it('should convert a base64-encoded string to its value', function() {
+      const value = Buffer.from('bXkgYnVmZmVy');
+      expect(decoders.base64(value), 'to equal', 'my buffer');
+    });
+  });
+
+  describe('text', function() {
+    it('should convert a value to a string', function() {
+      const value = Buffer.from('123');
+      expect(decoders.text(value), 'to equal', '123');
+    });
+  });
+
+  describe('binary', function() {
+    it('should just return the value', function() {
+      const value = Buffer.from('your mom');
+      expect(decoders.binary(value), 'to equal', value);
+    });
+  });
+});

--- a/test/encoders.spec.js
+++ b/test/encoders.spec.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+'use strict';
+
+const expect = require('unexpected');
+const encoders = require('../lib/encoders');
+
+describe('encoders', function() {
+  describe('json', function() {
+    it('should convert a value to a JSON string', function() {
+      const value = {foo: 'bar'};
+      expect(encoders.json(value), 'to equal', JSON.stringify(value));
+    });
+  });
+
+  describe('base64', function() {
+    it('should convert a value to a base64-encoded string', function() {
+      const value = Buffer.from('my buffer');
+      expect(encoders.base64(value), 'to equal', 'bXkgYnVmZmVy');
+    });
+  });
+
+  describe('text', function() {
+    it('should convert a value to a string', function() {
+      const value = 123;
+      expect(encoders.text(value), 'to equal', '123');
+    });
+  });
+
+  describe('binary', function() {
+    it('should convert a value to a buffer', function() {
+      const value = 'your mom';
+      expect(encoders.binary(value), 'to equal', Buffer.from('your mom'));
+    });
+  });
+});


### PR DESCRIPTION
- adds `text`, `json`, `binary`, and `base64` encoders and decoders to
be used with `publish()` and `subscribe()`, respectively
- can set defaults with options to `connect()`
- the default is `text` for both encoder and decoder
- update docs, tests